### PR TITLE
Fix CI tests by using auto.Pilot for terminal input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all:
 	$(SET) "CGO_ENABLED=0" && pushd "cmd/box" && $(GO) build -o ../../$(NAME)$(EXE) $(GOOPT) && popd
 
 test:
-	$(GO) test -v
+	$(GO) test -v ./...
 
 _dist:
 	$(MAKE) all

--- a/main_test.go
+++ b/main_test.go
@@ -11,10 +11,17 @@ import (
 func TestPrint(t *testing.T) {
 	var buffer strings.Builder
 
-	Println([]string{
+	b := &Box{Tty: &auto.Pilot{}}
+	err := b.Open()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer b.Close()
+
+	b.Println([]string{
 		"aaaa", "bbbb", "cccc", "fjdaksljflkdajfkljsalkfjdlkf",
 		"jfkldsjflkjdsalkfjlkdsajflkajds",
-		"fsdfsdf"}, &buffer)
+		"fsdfsdf"}, 0, &buffer)
 
 	actual := buffer.String()
 	expect := `aaaa                            fjdaksljflkdajfkljsalkfjdlkf


### PR DESCRIPTION
- TestPrint was failing on CI.
- Cause: Println calls were trying to get terminal width, which fails in the GitHub Actions environment.
- Solution: Explicitly use the pseudo terminal auto.Pilot to provide terminal input and avoid the error.
- Note: This only affects the test functions; no release update is required.

---

- テスト関数 TestPrint でエラーが発生していた。
- 原因は Println 関数を呼ぶ際に、CI 環境で端末の桁数取得に失敗していたせいだった。
- 明示的に、疑似端末：auto.Pilot を設定することでエラーを回避することにした。
- テスト関数だけの問題なので、リリースを更新する必要はないと考えられる。