### PR TITLE
Update `go-ttyadapter` to v0.3.0 and use `go-ttyadapter/tty8pe` instead of `tty8`

### DIFF
--- a/box.go
+++ b/box.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 
 	"github.com/nyaosorg/go-ttyadapter"
-	"github.com/nyaosorg/go-ttyadapter/tty8"
+	"github.com/nyaosorg/go-ttyadapter/tty8pe"
 
 	"github.com/nyaosorg/go-box/v3/grid"
 
@@ -20,8 +20,8 @@ type Box struct {
 	ttyadapter.Tty
 }
 
-// New creates and initializes a Box using the default terminal backend (tty8).
-// It is equivalent to creating a Box with &tty8.Tty{} and calling Open().
+// New creates and initializes a Box using the default terminal backend (tty8pe).
+// It is equivalent to creating a Box with &tty8pe.Tty{} and calling Open().
 //
 // Example:
 //
@@ -34,7 +34,7 @@ type Box struct {
 // Use this function when you do not need to customize the terminal input.
 func New() (*Box, error) {
 	b := &Box{
-		Tty: &tty8.Tty{},
+		Tty: &tty8pe.Tty{},
 	}
 	return b, b.Open()
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/nyaosorg/go-ttyadapter v0.0.1
+	github.com/nyaosorg/go-ttyadapter v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byF
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
-github.com/nyaosorg/go-ttyadapter v0.0.1 h1:4VslnofOrGLqXvVeKwz51BDR+Q82D2Iitk51urYRLGo=
-github.com/nyaosorg/go-ttyadapter v0.0.1/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
+github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=
+github.com/nyaosorg/go-ttyadapter v0.3.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/release_note.md
+++ b/release_note.md
@@ -1,5 +1,7 @@
 ( **English** / [Japanese](./release_note_ja.md) )
 
+- Update go-ttyadapter to v0.3.0 and use `go-ttyadapter/tty8pe` instead of `tty8` (#5)
+
 v3.0.0
 ======
 Nov 1, 2025


### PR DESCRIPTION
- Update `go-ttyadapter` from v0.0.1 to v0.3.0
- Use `go-ttyadapter/tty8pe` instead of `tty8`