### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,8 @@ on:
 jobs:
 
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/nyaosorg/go-box/security/code-scanning/1](https://github.com/nyaosorg/go-box/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block to limit the `GITHUB_TOKEN` to the minimum required scopes. For a simple Go CI job that checks out code and runs build/tests without modifying the repository or interacting with issues/PRs, `contents: read` is sufficient.

The best fix here is to add a job-level `permissions:` block under the `build` job (the code region CodeQL flagged), setting `contents: read`. This documents the workflow’s needs and ensures the token cannot gain broader permissions if org defaults change. Concretely, in `.github/workflows/go.yml`, between `build:` and `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
