### PR TITLE
`Meta`+`Ctrl`+`G` and `Meta`+`Ctrl`+`C` can now be used to cancel input

### DIFF
--- a/box.go
+++ b/box.go
@@ -155,7 +155,8 @@ func (b *Box) SelectIndex(sources []string, multi bool, out io.Writer) ([]int, e
 					result = []int{cursor}
 				}
 				return result, nil
-			case "\x1B", keys.CtrlG, keys.CtrlC:
+			case keys.CtrlG, keys.Escape + keys.CtrlG,
+				keys.CtrlC, keys.Escape + keys.CtrlC:
 				return []int{}, nil
 			}
 

--- a/internal/keys/main.go
+++ b/internal/keys/main.go
@@ -16,4 +16,5 @@ const (
 	CtrlRight = "\x1B[1;5C"
 	CtrlUp    = "\x1B[1;5A"
 	ShiftTab  = "\x1B[Z"
+	Escape    = "\x1B"
 )

--- a/release_note.md
+++ b/release_note.md
@@ -1,6 +1,8 @@
 Release notes
 =============
 
+- `Meta`+`Ctrl`+`G` and `Meta`+`Ctrl`+`C` can now be used to cancel input (#11)
+
 v3.1.0
 ------
 Feb 10, 2026

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -3,6 +3,8 @@
 
 ( [English](./release_note.md) / **Japanese** )
 
+- `Meta`+`Ctrl`+`G` と `Meta`+`Ctrl`+`C` も `Ctrl`+`G` と同様に機能するようにした。(#11)
+
 v3.1.0
 ------
 Feb 10, 2026


### PR DESCRIPTION
(English)
- `Meta`+`Ctrl`+`G` and `Meta`+`Ctrl`+`C` can now be used to cancel input

(Japanese)
- `Meta`+`Ctrl`+`G` と `Meta`+`Ctrl`+`C` も `Ctrl`+`G` と同様に機能するようにした。